### PR TITLE
Change the display PHP version for the bundled PHP

### DIFF
--- a/app/js/binary.operations.js
+++ b/app/js/binary.operations.js
@@ -94,14 +94,14 @@ function binaryUpdateList() {
   let versions = conf.get('php.versions');
   const inUse = conf.get('php.default');
 
-  // Adds bundled version manually
-  if (!versions) versions = [];
-  versions.bundled = 'Integrated version';
-
   // Rewrites PHP versions list
   Object.keys(versions).forEach((v) => {
     $('#binary-list').append(binaryLineGetTemplate(v, versions[v], (inUse === v)));
   });
+
+  // Adds bundled version manually
+  let bundledVersion = binaryGetVersion(getBundledPhpPath(), false);
+  $('#binary-list').append(binaryLineGetTemplate(bundledVersion, 'Integrated version', (inUse === 'bundled')));
 }
 
 /**

--- a/app/js/binary.operations.js
+++ b/app/js/binary.operations.js
@@ -91,7 +91,7 @@ function binaryLineGetTemplate(version, path, inUse) {
 function binaryUpdateList() {
   $('#binary-list').empty();
 
-  let versions = conf.get('php.versions');
+  const versions = conf.get('php.versions');
   const inUse = conf.get('php.default');
 
   // Rewrites PHP versions list
@@ -100,7 +100,7 @@ function binaryUpdateList() {
   });
 
   // Adds bundled version manually
-  let bundledVersion = binaryGetVersion(getBundledPhpPath(), false);
+  const bundledVersion = binaryGetVersion(getBundledPhpPath(), false);
   $('#binary-list').append(binaryLineGetTemplate(bundledVersion, 'Integrated version', (inUse === 'bundled')));
 }
 


### PR DESCRIPTION
Rather than adding the bundled version to the list used to generate the
version lines, instead append an extra line on the end. This allows for
passing of the version number, while still being able to check if it's
in use - the previous method of checking the `php.default` would not
longer work, as the version index is now the version number instead of
`bundled`. Instead, manually check the `php.default` against `bundled`
for this additional line.

Fixes #160