### PR TITLE
Fix missing systemPreferences variable on Windows

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -9,7 +9,7 @@ const electron = require('electron');
 const Path = require('path');
 const Configstore = require('configstore');
 
-const { app, Tray, Menu, BrowserWindow } = electron;
+const { app, Tray, Menu, BrowserWindow, systemPreferences } = electron;
 const ipc = electron.ipcMain;
 const dialog = electron.Dialog;
 


### PR DESCRIPTION
On Windows it fails with the following error
![image](https://user-images.githubusercontent.com/1611547/47118109-9e5a1100-d266-11e8-91c8-eaa78d62f969.png)
at
https://github.com/rafajaques/php-assistant/blob/f49ae3625994bb6ebe137b012a3f978a09c3a5c1/app/main.js#L88-L88