### PR TITLE
Various fixes to handle the bundled version properly

### DIFF
--- a/app/js/binary.operations.js
+++ b/app/js/binary.operations.js
@@ -116,14 +116,16 @@ function binaryUpdateList() {
   const inUse = conf.get('php.default');
 
   // Rewrites PHP versions list
-  Object.keys(versions).forEach((v) => {
-    $('#binary-list').append(binaryLineGetTemplate(v, versions[v], (inUse === v)));
-  });
+  if (versions) {
+    Object.keys(versions).forEach((v) => {
+      $('#binary-list').append(binaryLineGetTemplate(v, versions[v], (inUse === v)));
+    });
+  }
 
   // Adds bundled version manually
   const bundledVersion = binaryGetBundledVersion();
   $('#binary-list').append(
-    binaryLineGetTemplate(bundledVersion, i18n.__('Bundled version'), (inUse === bundledVersion)));
+    binaryLineGetTemplate(bundledVersion, i18n.__('Bundled version'), (inUse === "bundled")));
 }
 
 /**
@@ -133,7 +135,7 @@ function phpGetCurrVersion() {
   const curr = conf.get('php.default');
 
   if (curr) {
-    return binaryConvertVersionToShow(conf.get('php.default'));
+    return binaryConvertVersionToShow(curr === "bundled" ? binaryGetBundledVersion() : curr);
   }
 
   return false;
@@ -142,7 +144,7 @@ function phpGetCurrVersion() {
 /* Updates binary path used by the runner */
 function updatePhpPath() {
   // Are we using bundled version?
-  if (conf.get('php.default') === binaryGetBundledVersion()) {
+  if (conf.get('php.default') === "bundled") {
     phpPath = getBundledPhpPath();
   } else {
     phpPath = conf.get('php.versions.' + conf.get('php.default'));


### PR DESCRIPTION
On the first run the welcome page set the `php.default` config as `bundled`
https://github.com/rafajaques/php-assistant/blob/f49ae3625994bb6ebe137b012a3f978a09c3a5c1/app/js/welcome.js#L96

in `app/js/binary.operations.js` it reads the `php.default` config and expected a numeric version instead of the string "bundled".

This patch add checks for the `bundled` string in order to find the bundled php path, the version to show in the UI.

It also fixes an exception thrown when there aren't versions configured in the config file.

PS: with this fix and the #193 it works successfully on Windows 10 without php installed in the system. 